### PR TITLE
Cross-platform support (Linux/MacOS)

### DIFF
--- a/command.odin
+++ b/command.odin
@@ -13,6 +13,20 @@ import "core:runtime"
 // 	fmt.print(string(data[:]))
 // }
 
+when ODIN_OS == .Darwin {
+	foreign import lc "system:System.framework"
+} else when ODIN_OS == .Linux {
+	foreign import lc "system:c"
+}
+
+when ODIN_OS == .Darwin || ODIN_OS == .Linux {
+	@(default_calling_convention = "c")
+	foreign lc {
+		popen :: proc(command: cstring, mode: cstring) -> ^libc.FILE ---
+		pclose :: proc(stream: ^libc.FILE) -> int ---
+	}
+}
+
 // Adapted from: https://codereview.stackexchange.com/questions/188630/send-command-and-get-response-from-windows-cmd-prompt-silently-follow-up
 HANDLE :: windows.HANDLE
 IO_Pipes :: struct {

--- a/command.odin
+++ b/command.odin
@@ -13,6 +13,13 @@ import "core:runtime"
 // 	fmt.print(string(data[:]))
 // }
 
+foreign import kernel32 "system:Kernel32.lib"
+@(default_calling_convention = "stdcall")
+foreign kernel32 {
+	SetCommTimeouts :: proc(hFile: windows.HANDLE, lpCommTimeouts: ^COMMTIMEOUTS) -> windows.BOOL ---
+	PeekNamedPipe :: proc(hNamedPipe: windows.HANDLE, lpBuffer: rawptr, nBufferSize: windows.DWORD, lpBytesRead: ^windows.DWORD, lpTotalBytesAvail: ^windows.DWORD, lpBytesLeftThisMessage: ^windows.DWORD) -> windows.BOOL ---
+}
+
 when ODIN_OS == .Darwin {
 	foreign import lc "system:System.framework"
 } else when ODIN_OS == .Linux {
@@ -125,12 +132,7 @@ COMMTIMEOUTS :: struct {
 	WriteTotalTimeoutMultiplier: windows.DWORD, /* Multiplier of characters.        */
 	WriteTotalTimeoutConstant:   windows.DWORD, /* Constant in milliseconds.        */
 }
-foreign import kernel32 "system:Kernel32.lib"
-@(default_calling_convention = "stdcall")
-foreign kernel32 {
-	SetCommTimeouts :: proc(hFile: windows.HANDLE, lpCommTimeouts: ^COMMTIMEOUTS) -> windows.BOOL ---
-	PeekNamedPipe :: proc(hNamedPipe: windows.HANDLE, lpBuffer: rawptr, nBufferSize: windows.DWORD, lpBytesRead: ^windows.DWORD, lpTotalBytesAvail: ^windows.DWORD, lpBytesLeftThisMessage: ^windows.DWORD) -> windows.BOOL ---
-}
+
 
 read_from_pipe :: proc(buf: ^[dynamic]byte, size: int, io: ^IO_Pipes) {
 	// pk_len:windows.DWORD

--- a/command.odin
+++ b/command.odin
@@ -56,7 +56,7 @@ cmd :: proc(
 			read_from_pipe(&data, read_size, &io)
 		}
 		ok = true
-	} else when ODIN_OS == .Linux || ODIN_OS == .Linux {
+	} else when ODIN_OS == .Darwin || ODIN_OS == .Linux {
 		cmd_cstr := strings.clone_to_cstring(cmd)
 		defer delete(cmd_cstr)
 		file := popen(cmd_cstr, cstring("r"))

--- a/command.odin
+++ b/command.odin
@@ -1,4 +1,3 @@
-//+build Windows
 package cmd
 
 import "core:sys/windows"
@@ -6,19 +5,13 @@ import "core:mem"
 import "core:fmt"
 import "core:strings"
 import "core:c"
+import "core:c/libc"
 import "core:runtime"
 //
 // main :: proc() {
 // 	data, err := cmd("odin version", true, 128)
 // 	fmt.print(string(data[:]))
 // }
-
-foreign import kernel32 "system:Kernel32.lib"
-@(default_calling_convention = "stdcall")
-foreign kernel32 {
-	SetCommTimeouts :: proc(hFile: windows.HANDLE, lpCommTimeouts: ^COMMTIMEOUTS) -> windows.BOOL ---
-	PeekNamedPipe :: proc(hNamedPipe: windows.HANDLE, lpBuffer: rawptr, nBufferSize: windows.DWORD, lpBytesRead: ^windows.DWORD, lpTotalBytesAvail: ^windows.DWORD, lpBytesLeftThisMessage: ^windows.DWORD) -> windows.BOOL ---
-}
 
 when ODIN_OS == .Darwin {
 	foreign import lc "system:System.framework"
@@ -34,14 +27,6 @@ when ODIN_OS == .Darwin || ODIN_OS == .Linux {
 	}
 }
 
-// Adapted from: https://codereview.stackexchange.com/questions/188630/send-command-and-get-response-from-windows-cmd-prompt-silently-follow-up
-HANDLE :: windows.HANDLE
-IO_Pipes :: struct {
-	read_in:   HANDLE,
-	write_in:  HANDLE,
-	read_out:  HANDLE,
-	write_out: HANDLE,
-}
 cmd :: proc(
 	cmd: string,
 	get_response := true,
@@ -71,96 +56,20 @@ cmd :: proc(
 			read_from_pipe(&data, read_size, &io)
 		}
 		ok = true
+	} else when ODIN_OS == .Linux || ODIN_OS == .Linux {
+		cmd_cstr := strings.clone_to_cstring(cmd)
+		defer delete(cmd_cstr)
+		file := popen(cmd_cstr, cstring("r"))
+
+		ok = file != nil
+
+		if ok && get_response {
+			data = make_dynamic_array_len([dynamic]u8, read_size)
+			cstr := libc.fgets(cast(^byte)&data[0], i32(read_size), file)
+			ok = cstr != nil
+		}
+		pclose(file)
 	}
 
 	return
-}
-//
-setup_child_io_pipes :: proc(io: ^IO_Pipes, sa_attr: ^windows.SECURITY_ATTRIBUTES) -> (ok: bool) {
-	if !windows.CreatePipe(&io.read_out, &io.write_out, sa_attr, 0) {
-		return
-	}
-	if !windows.SetHandleInformation(io.read_out, windows.HANDLE_FLAG_INHERIT, 0) {
-		return
-	}
-	if !windows.CreatePipe(&io.read_in, &io.write_in, sa_attr, 0) {
-		return
-	}
-	if !windows.SetHandleInformation(io.write_in, windows.HANDLE_FLAG_INHERIT, 0) {
-		return
-	}
-	return true
-}
-//
-create_child_process :: proc(cmd: string, io: ^IO_Pipes) -> (ok: bool) {
-	pi: windows.PROCESS_INFORMATION = {}
-	si: windows.STARTUPINFOW = {
-		cb         = size_of(windows.STARTUPINFOW),
-		hStdError  = io.write_out,
-		hStdOutput = io.write_out,
-		hStdInput  = io.read_in,
-		dwFlags    = windows.STARTF_USESTDHANDLES,
-	}
-	wcmd: [^]u16 = windows.utf8_to_wstring(cmd, context.temp_allocator)
-	defer delete(wcmd[:len(cmd) + 1], context.temp_allocator) // <-- segfaults
-
-	success := windows.CreateProcessW(
-		nil,
-		wcmd,
-		nil,
-		nil,
-		windows.TRUE,
-		windows.CREATE_NO_WINDOW,
-		nil,
-		nil,
-		&si,
-		&pi,
-	)
-	if !success {
-		return
-	} else {
-		// windows.WaitForSingleObject(pi.hProcess, windows.INFINITE)
-		windows.CloseHandle(pi.hProcess)
-		windows.CloseHandle(pi.hThread)
-		windows.CloseHandle(io.write_out)
-	}
-	return true
-}
-//
-COMMTIMEOUTS :: struct {
-	ReadIntervalTimeout:         windows.DWORD, /* Maximum time between read chars. */
-	ReadTotalTimeoutMultiplier:  windows.DWORD, /* Multiplier of characters.        */
-	ReadTotalTimeoutConstant:    windows.DWORD, /* Constant in milliseconds.        */
-	WriteTotalTimeoutMultiplier: windows.DWORD, /* Multiplier of characters.        */
-	WriteTotalTimeoutConstant:   windows.DWORD, /* Constant in milliseconds.        */
-}
-
-
-read_from_pipe :: proc(buf: ^[dynamic]byte, size: int, io: ^IO_Pipes) {
-	// pk_len:windows.DWORD
-	// PeekNamedPipe(io.read_out, nil,0,nil, &pk_len, nil)
-	ct := COMMTIMEOUTS{}
-	ct.ReadTotalTimeoutConstant = 0
-	success: windows.BOOL
-	SetCommTimeouts(io.read_out, &ct)
-	last_start_index := 0
-	buf_struct := transmute(^runtime.Raw_Dynamic_Array)buf
-	for {
-		// note: in theory size is decremented by the dw_read, and cap(buf) is decremented by the same, net no need to do?
-		if cap(buf) < size {
-			reserve(buf, size) // ensure we have room in our buffer before reading
-		}
-		dw_read: windows.DWORD = 0
-		success = windows.ReadFile(
-			io.read_out,
-			&buf[last_start_index],
-			u32(size) - 1,
-			&dw_read,
-			nil,
-		)
-		buf_struct.len += int(dw_read) // manually adjust the len of dyn arr
-
-		if !success {break}
-		last_start_index += int(dw_read)
-	}
 }


### PR DESCRIPTION
## Changes
+ Moved windows code to `pipes_windows.odin`
+ Added foreign imports for `system:system.framework` (MacOS) and `system:c` (Linux).
+ Added `popen` and `pclose` from system library
+ Added Linux/Darwin code to `cmd()`

## Test code
```odin
package cmd 

import "core:fmt"

main :: proc() {
    data, ok := cmd("odin version")
    fmt.println(string(data[:]), ok)
    delete(data)
}
```
### Output
```
odin version dev-2023-07
 true
```

### Valgrind output
```
==151294== Memcheck, a memory error detector
==151294== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==151294== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==151294== Command: ./odin-command.bin
==151294== 
odin version dev-2023-07
 true
==151294== 
==151294== HEAP SUMMARY:
==151294==     in use at exit: 0 bytes in 0 blocks
==151294==   total heap usage: 5 allocs, 5 frees, 8,747 bytes allocated
==151294== 
==151294== All heap blocks were freed -- no leaks are possible
==151294== 
==151294== For lists of detected and suppressed errors, rerun with: -s
==151294== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

### Test information (odin report)
```
        Odin: dev-2023-07
        OS:   EndeavourOS, Linux 6.4.2-arch1-1
        CPU:  AMD Ryzen 5 3600 6-Core Processor              
        RAM:  15913 MiB
```
